### PR TITLE
Fix bug in getTemporaryIds()

### DIFF
--- a/app/src/main/java/io/bluetrace/opentrace/idmanager/TempIDManager.kt
+++ b/app/src/main/java/io/bluetrace/opentrace/idmanager/TempIDManager.kt
@@ -135,7 +135,7 @@ object TempIDManager {
                 )
                 Preference.putLastFetchTimeInMillis(
                     context,
-                    System.currentTimeMillis() * 1000
+                    System.currentTimeMillis()
                 )
             }
 


### PR DESCRIPTION
There is no need to multiply `System.currentTimeMillis()` by 1000 as it is already in milliseconds.

Also, it is better to use [Instant](https://developer.android.com/reference/kotlin/java/time/Instant), instead of performing accident-prone conversions (which appear often in the current code).