### PR TITLE
Fix the Uknown pattern character 'Y' exception

### DIFF
--- a/app/src/main/java/io/bluetrace/opentrace/fragment/EnterPinFragment.kt
+++ b/app/src/main/java/io/bluetrace/opentrace/fragment/EnterPinFragment.kt
@@ -227,7 +227,7 @@ class EnterPinFragment : Fragment() {
         val storage = FirebaseStorage.getInstance("gs://${bucketName}")
         var storageRef = storage.getReferenceFromUrl("gs://${bucketName}")
 
-        val dateString = SimpleDateFormat("YYYYMMdd").format(Date())
+        val dateString = SimpleDateFormat("yyyyMMdd").format(Date())
         var streetPassRecordsRef =
             storageRef.child("streetPassRecords/$dateString/${fileToUpload.name}")
 


### PR DESCRIPTION
The uppercase Ys used in SimpleDateFormat at line 230, throws the exception: " Uknown pattern character 'Y' " in the APIs 22 and 23, as you can see in the link below the character Y is supported by API 24+, so the Ys should be replaced by lowercases.

https://developer.android.com/reference/java/text/SimpleDateFormat.html