### PR TITLE
Changing minsdk from 22 to 21

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -33,7 +33,7 @@ android {
     defaultConfig {
         applicationId "io.bluetrace.opentrace"
         resValue "string", "build_config_package", "io.bluetrace.opentrace"
-        minSdkVersion 22
+        minSdkVersion 21
         targetSdkVersion 29
         versionCode 41
         versionName "1.0.41"


### PR DESCRIPTION
I've noticed that Bluetrace/Opentrace has the minsdk set at 22 although when changed to 21, it seems to compile and run on the Android emulator running Android 5.0 successfully, admittedly I personally haven't got past the sign up screen as I haven't connected it to a Firebase instance. 

I am aware of the limitations of the GATT implementation with the use 512 byte MTU payloads and that potentially not working well with older bluetooth controllers. The @covidsafewatch community is looking to test it but hasn't had the time.

In the [testing methodologies repository](https://github.com/opentrace-community/opentrace-calibration/blob/master/Device%20Data.csv), the oldest Android device tested was the Nexus 5X which was launched with Android 6.0 (API Level 23). There doesn't seem to be an public knowledge of Android 5.1 being tested.

I was wondering if either this pull request could be merged or if you could give insight as to why the minsdk is set at 22.

In no particular order, I'd like to give a very special thanks to:
- @KonajuGames
- @ghuntley
- @micolous
- @WeilonYing

They have done an amazing job helping me out 🙂